### PR TITLE
Add login module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # smartops-web
+
+SmartOps Web is a Vue 3 management console template featuring a login page and a complete asset management module.
+
+## Features
+- Switchable Local and LDAP authentication
+- CRUD pages for Customers, Sites, Remote Access and Host Assets
+- Dynamic routing via Vue Router
+- State management with Pinia and data fetching through @tanstack/vue-query
+- Element Plus UI components with optional Tailwind CSS
+
+## Getting Started
+1. Install Node.js (v18 recommended).
+2. Run `npm install` to install dependencies.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+4. Visit `http://localhost:5173` in your browser.
+
+## Building for Production
+```bash
+npm run build
+```
+
+---
+
+## \u4E2D\u6587\u8BF4\u660E (Chinese)
+
+SmartOps Web \u662F\u4E00\u4E2A Vue 3 \u9879\u76EE\uFF0C\u5305\u542B\u767B\u5F55\u9875\u9762\u548C\u8D44\u4EA7\u7BA1\u7406\u6A21\u5757\u3002
+
+### \u529F\u80FD
+- \u652F\u6301\u672C\u5730\u548C LDAP \u767B\u5F55\u5207\u6362
+- \u5BA2\u6237\u3001\u573A\u5730\u3001\u8FDC\u7A0B\u8BBF\u95EE\u548C\u4E3B\u673A\u8D44\u4EA7\u7684 CRUD \u64CD\u4F5C
+- Vue Router \u52A8\u6001\u8DEF\u7531
+- Pinia \u72B6\u6001\u7BA1\u7406\u548C vue-query \u6570\u636E\u83B7\u53D6
+- Element Plus UI \u914D\u5408 Tailwind CSS
+
+### \u5F00\u53D1
+1. \u5B89\u88C5 Node.js (\u5EFA\u8BAE v18)
+2. \u6267\u884C `npm install` \u5B89\u88C5\u4F9D\u8D56
+3. \u542F\u52A8\u5F00\u53D1\u670D\u52A1:
+   ```bash
+   npm run dev
+   ```
+4. \u5728\u6D4F\u89C8\u5668\u8BBF\u95EE `http://localhost:5173`
+
+### \u6784\u5EFA
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SmartOps</title>
+  <script type="module" src="/src/main.ts"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "smartops-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/vue-query": "^4.34.3",
+    "axios": "^1.6.8",
+    "element-plus": "^2.5.3",
+    "pinia": "^2.1.4",
+    "vue": "^3.4.15",
+    "vue-router": "^4.2.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^4.5.1",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,6 @@
+<template>
+  <router-view />
+</template>
+
+<script setup lang="ts">
+</script>

--- a/src/api/assetApi.ts
+++ b/src/api/assetApi.ts
@@ -1,0 +1,51 @@
+import axios from 'axios'
+import { Customer, Site, RemoteAccess, HostAsset } from '../modules/asset/types'
+
+const apiClient = axios.create({
+  baseURL: '/api/asset',
+})
+
+// Customer APIs
+export const fetchCustomers = (params?: any) =>
+  apiClient.get<Customer[]>('/customers', { params })
+export const fetchCustomer = (id: number) =>
+  apiClient.get<Customer>(`/customers/${id}`)
+export const createCustomer = (data: Partial<Customer>) =>
+  apiClient.post('/customers', data)
+export const updateCustomer = (id: number, data: Partial<Customer>) =>
+  apiClient.put(`/customers/${id}`, data)
+export const deleteCustomer = (id: number) =>
+  apiClient.delete(`/customers/${id}`)
+
+// Site APIs
+export const fetchSites = (params?: any) =>
+  apiClient.get<Site[]>('/sites', { params })
+export const fetchSite = (id: number) =>
+  apiClient.get<Site>(`/sites/${id}`)
+export const createSite = (data: Partial<Site>) =>
+  apiClient.post('/sites', data)
+export const updateSite = (id: number, data: Partial<Site>) =>
+  apiClient.put(`/sites/${id}`, data)
+export const deleteSite = (id: number) =>
+  apiClient.delete(`/sites/${id}`)
+
+// RemoteAccess APIs
+export const fetchRemoteAccesses = (params?: any) =>
+  apiClient.get<RemoteAccess[]>('/remote-access', { params })
+export const createRemoteAccess = (data: Partial<RemoteAccess>) =>
+  apiClient.post('/remote-access', data)
+export const updateRemoteAccess = (id: number, data: Partial<RemoteAccess>) =>
+  apiClient.put(`/remote-access/${id}`, data)
+export const deleteRemoteAccess = (id: number) =>
+  apiClient.delete(`/remote-access/${id}`)
+
+// HostAsset APIs
+export const fetchHostAssets = (params?: any) =>
+  apiClient.get<HostAsset[]>('/host-assets', { params })
+export const createHostAsset = (data: Partial<HostAsset>) =>
+  apiClient.post('/host-assets', data)
+export const updateHostAsset = (id: number, data: Partial<HostAsset>) =>
+  apiClient.put(`/host-assets/${id}`, data)
+export const deleteHostAsset = (id: number) =>
+  apiClient.delete(`/host-assets/${id}`)
+

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+const authClient = axios.create({
+  baseURL: '/api/auth',
+})
+
+export interface LoginPayload {
+  username: string
+  password: string
+}
+
+export const loginLocal = (data: LoginPayload) => authClient.post('/login', data)
+export const loginLdap = (data: LoginPayload) => authClient.post('/ldap', data)

--- a/src/components/FormDialog.vue
+++ b/src/components/FormDialog.vue
@@ -1,0 +1,19 @@
+<template>
+  <el-dialog v-model="visible" :title="title" @close="onClose">
+    <slot />
+    <template #footer>
+      <el-button @click="onClose">Cancel</el-button>
+      <el-button type="primary" @click="onOk">OK</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+
+const props = defineProps<{ title: string; visible: boolean }>()
+const emit = defineEmits(['update:visible', 'ok'])
+
+const onClose = () => emit('update:visible', false)
+const onOk = () => emit('ok')
+</script>

--- a/src/components/TableWrapper.vue
+++ b/src/components/TableWrapper.vue
@@ -1,0 +1,25 @@
+<template>
+  <el-table v-bind="$attrs" :data="data">
+    <slot />
+  </el-table>
+  <el-pagination
+    v-if="pagination"
+    class="mt-4"
+    layout="total, prev, pager, next"
+    :page-size="pagination.pageSize"
+    :total="pagination.total"
+    @current-change="pagination.onChange"
+  />
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue'
+
+interface Pagination {
+  pageSize: number
+  total: number
+  onChange: (page: number) => void
+}
+
+defineProps<{ data: any[]; pagination?: Pagination }>()
+</script>

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,0 +1,8 @@
+import { ref } from 'vue'
+
+export function useModal() {
+  const visible = ref(false)
+  const open = () => (visible.value = true)
+  const close = () => (visible.value = false)
+  return { visible, open, close }
+}

--- a/src/composables/usePaginated.ts
+++ b/src/composables/usePaginated.ts
@@ -1,0 +1,10 @@
+import { ref } from 'vue'
+
+export function usePaginated() {
+  const page = ref(1)
+  const pageSize = ref(10)
+  const total = ref(0)
+  const setTotal = (t: number) => (total.value = t)
+  const onChange = (p: number) => (page.value = p)
+  return { page, pageSize, total, setTotal, onChange }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import { router } from './router'
+import { pinia } from './stores'
+import '@tanstack/vue-query/dist/vue-query.css'
+import './styles/tailwind.css'
+
+createApp(App).use(router).use(pinia).mount('#app')

--- a/src/modules/asset/api.ts
+++ b/src/modules/asset/api.ts
@@ -1,0 +1,125 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import {
+  fetchCustomers,
+  fetchCustomer,
+  createCustomer,
+  updateCustomer,
+  deleteCustomer,
+  fetchSites,
+  fetchSite,
+  createSite,
+  updateSite,
+  deleteSite,
+  fetchRemoteAccesses,
+  createRemoteAccess,
+  updateRemoteAccess,
+  deleteRemoteAccess,
+  fetchHostAssets,
+  createHostAsset,
+  updateHostAsset,
+  deleteHostAsset,
+} from '../../api/assetApi'
+import { Customer, Site, RemoteAccess, HostAsset } from './types'
+
+export const useCustomerList = (params?: any) =>
+  useQuery(['customers', params], () => fetchCustomers(params).then(r => r.data))
+
+export const useCustomer = (id: number) =>
+  useQuery(['customer', id], () => fetchCustomer(id).then(r => r.data))
+
+export const useCreateCustomer = () => {
+  const qc = useQueryClient()
+  return useMutation((data: Partial<Customer>) => createCustomer(data), {
+    onSuccess: () => qc.invalidateQueries(['customers']),
+  })
+}
+
+export const useUpdateCustomer = () => {
+  const qc = useQueryClient()
+  return useMutation((payload: { id: number; data: Partial<Customer> }) => updateCustomer(payload.id, payload.data), {
+    onSuccess: () => qc.invalidateQueries(['customers']),
+  })
+}
+
+export const useDeleteCustomer = () => {
+  const qc = useQueryClient()
+  return useMutation((id: number) => deleteCustomer(id), {
+    onSuccess: () => qc.invalidateQueries(['customers']),
+  })
+}
+
+export const useSiteList = (params?: any) =>
+  useQuery(['sites', params], () => fetchSites(params).then(r => r.data))
+
+export const useSite = (id: number) =>
+  useQuery(['site', id], () => fetchSite(id).then(r => r.data))
+
+export const useCreateSite = () => {
+  const qc = useQueryClient()
+  return useMutation((data: Partial<Site>) => createSite(data), {
+    onSuccess: () => qc.invalidateQueries(['sites']),
+  })
+}
+
+export const useUpdateSite = () => {
+  const qc = useQueryClient()
+  return useMutation((payload: { id: number; data: Partial<Site> }) => updateSite(payload.id, payload.data), {
+    onSuccess: () => qc.invalidateQueries(['sites']),
+  })
+}
+
+export const useDeleteSite = () => {
+  const qc = useQueryClient()
+  return useMutation((id: number) => deleteSite(id), {
+    onSuccess: () => qc.invalidateQueries(['sites']),
+  })
+}
+
+export const useRemoteAccessList = (params?: any) =>
+  useQuery(['remoteAccess', params], () => fetchRemoteAccesses(params).then(r => r.data))
+
+export const useCreateRemoteAccess = () => {
+  const qc = useQueryClient()
+  return useMutation((data: Partial<RemoteAccess>) => createRemoteAccess(data), {
+    onSuccess: () => qc.invalidateQueries(['remoteAccess']),
+  })
+}
+
+export const useUpdateRemoteAccess = () => {
+  const qc = useQueryClient()
+  return useMutation((payload: { id: number; data: Partial<RemoteAccess> }) => updateRemoteAccess(payload.id, payload.data), {
+    onSuccess: () => qc.invalidateQueries(['remoteAccess']),
+  })
+}
+
+export const useDeleteRemoteAccess = () => {
+  const qc = useQueryClient()
+  return useMutation((id: number) => deleteRemoteAccess(id), {
+    onSuccess: () => qc.invalidateQueries(['remoteAccess']),
+  })
+}
+
+export const useHostAssetList = (params?: any) =>
+  useQuery(['hostAssets', params], () => fetchHostAssets(params).then(r => r.data))
+
+export const useCreateHostAsset = () => {
+  const qc = useQueryClient()
+  return useMutation((data: Partial<HostAsset>) => createHostAsset(data), {
+    onSuccess: () => qc.invalidateQueries(['hostAssets']),
+  })
+}
+
+export const useUpdateHostAsset = () => {
+  const qc = useQueryClient()
+  return useMutation((payload: { id: number; data: Partial<HostAsset> }) => updateHostAsset(payload.id, payload.data), {
+    onSuccess: () => qc.invalidateQueries(['hostAssets']),
+  })
+}
+
+export const useDeleteHostAsset = () => {
+  const qc = useQueryClient()
+  return useMutation((id: number) => deleteHostAsset(id), {
+    onSuccess: () => qc.invalidateQueries(['hostAssets']),
+  })
+}
+

--- a/src/modules/asset/customer/CustomerDeleteDialog.vue
+++ b/src/modules/asset/customer/CustomerDeleteDialog.vue
@@ -1,0 +1,16 @@
+<template>
+  <FormDialog title="Delete Customer" v-model:visible="visible" @ok="confirm">
+    Are you sure to delete {{ data?.name }}?
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'confirm'])
+
+const confirm = () => emit('confirm')
+</script>

--- a/src/modules/asset/customer/CustomerDetail.vue
+++ b/src/modules/asset/customer/CustomerDetail.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <el-card class="mb-4" v-if="customer">
+      <div><strong>Name:</strong> {{ customer.name }}</div>
+      <div><strong>SLA:</strong> {{ customer.slaLevel }}</div>
+      <div><strong>Level:</strong> {{ customer.level }}</div>
+      <div><strong>Contract:</strong> {{ customer.contract }}</div>
+      <div><strong>Fee:</strong> {{ customer.feeInfo }}</div>
+    </el-card>
+    <h2 class="text-xl mb-2">Sites</h2>
+    <SiteList :customer-id="id" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps, computed } from 'vue'
+import { useCustomer } from '../api'
+import SiteList from '../site/SiteList.vue'
+
+const props = defineProps<{ id: number }>()
+const { data } = useCustomer(props.id)
+const customer = computed(() => data.value)
+</script>

--- a/src/modules/asset/customer/CustomerForm.vue
+++ b/src/modules/asset/customer/CustomerForm.vue
@@ -1,0 +1,59 @@
+<template>
+  <FormDialog :title="data?.id ? 'Edit Customer' : 'Add Customer'" v-model:visible="visible" @ok="onSubmit">
+    <el-form :model="form" ref="formRef">
+      <el-form-item label="Name" prop="name" :rules="{ required: true, message: 'Required' }">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item label="SLA" prop="slaLevel">
+        <el-input v-model="form.slaLevel" />
+      </el-form-item>
+      <el-form-item label="Level" prop="level">
+        <el-input v-model="form.level" />
+      </el-form-item>
+      <el-form-item label="Contract" prop="contract">
+        <el-input v-model="form.contract" />
+      </el-form-item>
+      <el-form-item label="Fee" prop="feeInfo">
+        <el-input v-model="form.feeInfo" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue'
+import { useCreateCustomer, useUpdateCustomer } from '../api'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'saved'])
+
+const formRef = ref()
+const form = ref({
+  name: '',
+  slaLevel: '',
+  level: '',
+  contract: '',
+  feeInfo: '',
+})
+
+watch(
+  () => props.data,
+  val => {
+    if (val) Object.assign(form.value, val)
+  },
+  { immediate: true }
+)
+
+const { mutateAsync: create } = useCreateCustomer()
+const { mutateAsync: update } = useUpdateCustomer()
+
+const onSubmit = async () => {
+  if (!formRef.value) return
+  const method = props.data?.id ? update({ id: props.data.id, data: form.value }) : create(form.value)
+  await method
+  emit('update:visible', false)
+  emit('saved')
+}
+</script>

--- a/src/modules/asset/customer/CustomerList.vue
+++ b/src/modules/asset/customer/CustomerList.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <el-input v-model="search" placeholder="Search" class="mb-2" />
+    <el-button type="primary" class="mb-2" @click="openForm">Add</el-button>
+    <TableWrapper :data="list" :pagination="{ pageSize: pageSize, total: total, onChange }">
+      <el-table-column prop="name" label="Name" />
+      <el-table-column prop="slaLevel" label="SLA" />
+      <el-table-column prop="level" label="Level" />
+      <el-table-column prop="contract" label="Contract" />
+      <el-table-column prop="feeInfo" label="Fee" />
+      <el-table-column label="Actions">
+        <template #default="{ row }">
+          <el-button size="small" @click="edit(row)">Edit</el-button>
+          <el-button size="small" type="danger" @click="remove(row)">Delete</el-button>
+          <el-button size="small" type="primary" @click="view(row)">Detail</el-button>
+        </template>
+      </el-table-column>
+    </TableWrapper>
+    <CustomerForm v-model:visible="formVisible" :data="current" @saved="refetch" />
+    <CustomerDeleteDialog v-model:visible="deleteVisible" :data="current" @confirm="doDelete" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useCustomerList, useDeleteCustomer } from '../api'
+import { useRouter } from 'vue-router'
+import TableWrapper from '@/components/TableWrapper.vue'
+import CustomerForm from './CustomerForm.vue'
+import CustomerDeleteDialog from './CustomerDeleteDialog.vue'
+import { usePaginated } from '@/composables/usePaginated'
+
+const search = ref('')
+const { page, pageSize, total, setTotal, onChange } = usePaginated()
+const { data, refetch } = useCustomerList({ search, page, pageSize })
+watch(data, () => setTotal(data.value?.length || 0))
+
+const list = data
+
+const formVisible = ref(false)
+const deleteVisible = ref(false)
+const current = ref()
+
+const openForm = () => {
+  current.value = undefined
+  formVisible.value = true
+}
+
+const edit = (row: any) => {
+  current.value = row
+  formVisible.value = true
+}
+
+const remove = (row: any) => {
+  current.value = row
+  deleteVisible.value = true
+}
+
+const { mutate } = useDeleteCustomer()
+const doDelete = () => {
+  mutate(current.value.id)
+  deleteVisible.value = false
+}
+
+const router = useRouter()
+const view = (row: any) => {
+  router.push(`/asset/customer/${row.id}`)
+}
+</script>

--- a/src/modules/asset/host-asset/HostAssetDeleteDialog.vue
+++ b/src/modules/asset/host-asset/HostAssetDeleteDialog.vue
@@ -1,0 +1,16 @@
+<template>
+  <FormDialog title="Delete Host" v-model:visible="visible" @ok="confirm">
+    Are you sure to delete {{ data?.hostname }}?
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'confirm'])
+
+const confirm = () => emit('confirm')
+</script>

--- a/src/modules/asset/host-asset/HostAssetForm.vue
+++ b/src/modules/asset/host-asset/HostAssetForm.vue
@@ -1,0 +1,64 @@
+<template>
+  <FormDialog :title="data?.id ? 'Edit Host' : 'Add Host'" v-model:visible="visible" @ok="onSubmit">
+    <el-form :model="form" ref="formRef">
+      <el-form-item label="Site" prop="siteId" :rules="{ required: true, message: 'Required' }">
+        <el-select v-model="form.siteId">
+          <el-option v-for="s in sites" :key="s.id" :label="s.name" :value="s.id" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="Hostname" prop="hostname" :rules="{ required: true, message: 'Required' }">
+        <el-input v-model="form.hostname" />
+      </el-form-item>
+      <el-form-item label="IP" prop="ip">
+        <el-input v-model="form.ip" />
+      </el-form-item>
+      <el-form-item label="OS" prop="os">
+        <el-input v-model="form.os" />
+      </el-form-item>
+      <el-form-item label="Status" prop="status">
+        <el-select v-model="form.status">
+          <el-option label="online" value="online" />
+          <el-option label="offline" value="offline" />
+        </el-select>
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue'
+import { useCreateHostAsset, useUpdateHostAsset, useSiteList } from '../api'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'saved'])
+
+const formRef = ref()
+const form = ref({
+  siteId: undefined,
+  hostname: '',
+  ip: '',
+  os: '',
+  status: 'online',
+})
+
+watch(
+  () => props.data,
+  val => {
+    if (val) Object.assign(form.value, val)
+  },
+  { immediate: true }
+)
+
+const { data: sites } = useSiteList()
+const { mutateAsync: create } = useCreateHostAsset()
+const { mutateAsync: update } = useUpdateHostAsset()
+
+const onSubmit = async () => {
+  const method = props.data?.id ? update({ id: props.data.id, data: form.value }) : create(form.value)
+  await method
+  emit('update:visible', false)
+  emit('saved')
+}
+</script>

--- a/src/modules/asset/host-asset/HostAssetList.vue
+++ b/src/modules/asset/host-asset/HostAssetList.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <el-select v-model="status" placeholder="Status" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option label="online" value="online" />
+      <el-option label="offline" value="offline" />
+    </el-select>
+    <el-select v-model="os" placeholder="OS" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option label="Windows" value="Windows" />
+      <el-option label="Linux" value="Linux" />
+    </el-select>
+    <el-select v-if="props.siteId === undefined" v-model="siteId" placeholder="Site" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option v-for="s in sites" :key="s.id" :label="s.name" :value="s.id" />
+    </el-select>
+    <el-input v-model="search" placeholder="Search" class="mb-2" />
+    <el-button type="primary" class="mb-2" @click="openForm">Add</el-button>
+    <TableWrapper :data="list" :pagination="{ pageSize, total, onChange }">
+      <el-table-column prop="hostname" label="Hostname" />
+      <el-table-column prop="ip" label="IP" />
+      <el-table-column prop="os" label="OS" />
+      <el-table-column prop="status" label="Status" />
+      <el-table-column prop="siteName" label="Site" />
+      <el-table-column label="Actions">
+        <template #default="{ row }">
+          <el-button size="small" @click="edit(row)">Edit</el-button>
+          <el-button size="small" type="danger" @click="remove(row)">Delete</el-button>
+        </template>
+      </el-table-column>
+    </TableWrapper>
+    <HostAssetForm v-model:visible="formVisible" :data="current" @saved="refetch" />
+    <HostAssetDeleteDialog v-model:visible="deleteVisible" :data="current" @confirm="doDelete" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps } from 'vue'
+import { useHostAssetList, useDeleteHostAsset, useSiteList } from '../api'
+import TableWrapper from '@/components/TableWrapper.vue'
+import HostAssetForm from './HostAssetForm.vue'
+import HostAssetDeleteDialog from './HostAssetDeleteDialog.vue'
+import { usePaginated } from '@/composables/usePaginated'
+
+const props = defineProps<{ siteId?: number }>()
+const siteId = ref(props.siteId ?? '')
+const status = ref('')
+const os = ref('')
+const search = ref('')
+const { data: sites } = useSiteList()
+const { page, pageSize, total, setTotal, onChange } = usePaginated()
+const { data, refetch } = useHostAssetList({ status, os, search, siteId, page, pageSize })
+watch(data, () => setTotal(data.value?.length || 0))
+
+const list = data
+const formVisible = ref(false)
+const deleteVisible = ref(false)
+const current = ref()
+
+const openForm = () => {
+  current.value = undefined
+  formVisible.value = true
+}
+
+const edit = (row: any) => {
+  current.value = row
+  formVisible.value = true
+}
+
+const remove = (row: any) => {
+  current.value = row
+  deleteVisible.value = true
+}
+
+const { mutate } = useDeleteHostAsset()
+const doDelete = () => {
+  mutate(current.value.id)
+  deleteVisible.value = false
+}
+</script>

--- a/src/modules/asset/index.ts
+++ b/src/modules/asset/index.ts
@@ -1,0 +1,4 @@
+export * from './api'
+export * from './router'
+export * from './store'
+export * from './types'

--- a/src/modules/asset/remote-access/RemoteAccessDeleteDialog.vue
+++ b/src/modules/asset/remote-access/RemoteAccessDeleteDialog.vue
@@ -1,0 +1,16 @@
+<template>
+  <FormDialog title="Delete Remote Access" v-model:visible="visible" @ok="confirm">
+    Are you sure to delete {{ data?.host }}?
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'confirm'])
+
+const confirm = () => emit('confirm')
+</script>

--- a/src/modules/asset/remote-access/RemoteAccessForm.vue
+++ b/src/modules/asset/remote-access/RemoteAccessForm.vue
@@ -1,0 +1,67 @@
+<template>
+  <FormDialog :title="data?.id ? 'Edit Remote Access' : 'Add Remote Access'" v-model:visible="visible" @ok="onSubmit">
+    <el-form :model="form" ref="formRef">
+      <el-form-item label="Type" prop="type" :rules="{ required: true, message: 'Required' }">
+        <el-select v-model="form.type">
+          <el-option label="SSH" value="SSH" />
+          <el-option label="RDP" value="RDP" />
+          <el-option label="VNC" value="VNC" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="Host" prop="host">
+        <el-input v-model="form.host" />
+      </el-form-item>
+      <el-form-item label="Port" prop="port">
+        <el-input v-model="form.port" />
+      </el-form-item>
+      <el-form-item label="Username" prop="username">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="Password" prop="passwordEncrypted">
+        <el-input :type="showPassword ? 'text' : 'password'" v-model="form.passwordEncrypted">
+          <template #suffix>
+            <el-button text @click="showPassword = !showPassword">{{ showPassword ? 'Hide' : 'Show' }}</el-button>
+          </template>
+        </el-input>
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue'
+import { useCreateRemoteAccess, useUpdateRemoteAccess } from '../api'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'saved'])
+
+const formRef = ref()
+const showPassword = ref(false)
+const form = ref({
+  type: 'SSH',
+  host: '',
+  port: 22,
+  username: '',
+  passwordEncrypted: '',
+})
+
+watch(
+  () => props.data,
+  val => {
+    if (val) Object.assign(form.value, val)
+  },
+  { immediate: true }
+)
+
+const { mutateAsync: create } = useCreateRemoteAccess()
+const { mutateAsync: update } = useUpdateRemoteAccess()
+
+const onSubmit = async () => {
+  const method = props.data?.id ? update({ id: props.data.id, data: form.value }) : create(form.value)
+  await method
+  emit('update:visible', false)
+  emit('saved')
+}
+</script>

--- a/src/modules/asset/remote-access/RemoteAccessList.vue
+++ b/src/modules/asset/remote-access/RemoteAccessList.vue
@@ -1,0 +1,74 @@
+<template>
+  <div>
+    <el-select v-model="type" placeholder="Type" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option label="SSH" value="SSH" />
+      <el-option label="RDP" value="RDP" />
+      <el-option label="VNC" value="VNC" />
+    </el-select>
+    <el-select v-if="props.siteId === undefined" v-model="siteId" placeholder="Site" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option v-for="s in sites" :key="s.id" :label="s.name" :value="s.id" />
+    </el-select>
+    <el-input v-model="search" placeholder="Search" class="mb-2" />
+    <el-button type="primary" class="mb-2" @click="openForm">Add</el-button>
+    <TableWrapper :data="list" :pagination="{ pageSize, total, onChange }">
+      <el-table-column prop="type" label="Type" />
+      <el-table-column prop="host" label="Host" />
+      <el-table-column prop="port" label="Port" />
+      <el-table-column prop="username" label="User" />
+      <el-table-column label="Actions">
+        <template #default="{ row }">
+          <el-button size="small" @click="edit(row)">Edit</el-button>
+          <el-button size="small" type="danger" @click="remove(row)">Delete</el-button>
+        </template>
+      </el-table-column>
+    </TableWrapper>
+    <RemoteAccessForm v-model:visible="formVisible" :data="current" @saved="refetch" />
+    <RemoteAccessDeleteDialog v-model:visible="deleteVisible" :data="current" @confirm="doDelete" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps } from 'vue'
+import { useRemoteAccessList, useDeleteRemoteAccess, useSiteList } from '../api'
+import TableWrapper from '@/components/TableWrapper.vue'
+import RemoteAccessForm from './RemoteAccessForm.vue'
+import RemoteAccessDeleteDialog from './RemoteAccessDeleteDialog.vue'
+import { usePaginated } from '@/composables/usePaginated'
+
+const props = defineProps<{ siteId?: number }>()
+const siteId = ref(props.siteId ?? '')
+const type = ref('')
+const search = ref('')
+const { data: sites } = useSiteList()
+const { page, pageSize, total, setTotal, onChange } = usePaginated()
+const { data, refetch } = useRemoteAccessList({ type, search, siteId, page, pageSize })
+watch(data, () => setTotal(data.value?.length || 0))
+
+const list = data
+const formVisible = ref(false)
+const deleteVisible = ref(false)
+const current = ref()
+
+const openForm = () => {
+  current.value = undefined
+  formVisible.value = true
+}
+
+const edit = (row: any) => {
+  current.value = row
+  formVisible.value = true
+}
+
+const remove = (row: any) => {
+  current.value = row
+  deleteVisible.value = true
+}
+
+const { mutate } = useDeleteRemoteAccess()
+const doDelete = () => {
+  mutate(current.value.id)
+  deleteVisible.value = false
+}
+</script>

--- a/src/modules/asset/router.ts
+++ b/src/modules/asset/router.ts
@@ -1,0 +1,30 @@
+import { RouteRecordRaw } from 'vue-router'
+
+export const assetRoutes: RouteRecordRaw[] = [
+  {
+    path: '/asset/customer',
+    component: () => import('./customer/CustomerList.vue'),
+  },
+  {
+    path: '/asset/customer/:id',
+    component: () => import('./customer/CustomerDetail.vue'),
+    props: route => ({ id: Number(route.params.id) })
+  },
+  {
+    path: '/asset/site',
+    component: () => import('./site/SiteList.vue'),
+  },
+  {
+    path: '/asset/site/:id',
+    component: () => import('./site/SiteDetail.vue'),
+    props: route => ({ id: Number(route.params.id) })
+  },
+  {
+    path: '/asset/remote-access',
+    component: () => import('./remote-access/RemoteAccessList.vue'),
+  },
+  {
+    path: '/asset/host-asset',
+    component: () => import('./host-asset/HostAssetList.vue'),
+  },
+]

--- a/src/modules/asset/site/SiteDeleteDialog.vue
+++ b/src/modules/asset/site/SiteDeleteDialog.vue
@@ -1,0 +1,16 @@
+<template>
+  <FormDialog title="Delete Site" v-model:visible="visible" @ok="confirm">
+    Are you sure to delete {{ data?.name }}?
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'confirm'])
+
+const confirm = () => emit('confirm')
+</script>

--- a/src/modules/asset/site/SiteDetail.vue
+++ b/src/modules/asset/site/SiteDetail.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <el-card class="mb-4" v-if="site">
+      <div><strong>Name:</strong> {{ site.name }}</div>
+      <div><strong>Customer:</strong> {{ site.customerName }}</div>
+      <div><strong>Contact:</strong> {{ site.contact }}</div>
+      <div><strong>Manager:</strong> {{ site.manager }}</div>
+      <div><strong>Location:</strong> {{ site.location }}</div>
+      <div><strong>Products:</strong> {{ site.deployedProducts.join(', ') }}</div>
+      <div><strong>Description:</strong> {{ site.description }}</div>
+    </el-card>
+    <RemoteAccessList v-if="site" :site-id="site.id" />
+    <HostAssetList v-if="site" :site-id="site.id" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue'
+import RemoteAccessList from '../remote-access/RemoteAccessList.vue'
+import HostAssetList from '../host-asset/HostAssetList.vue'
+import { useSite } from '../api'
+
+const props = defineProps<{ id: number }>()
+const { data: site } = useSite(props.id)
+</script>

--- a/src/modules/asset/site/SiteForm.vue
+++ b/src/modules/asset/site/SiteForm.vue
@@ -1,0 +1,72 @@
+<template>
+  <FormDialog :title="data?.id ? 'Edit Site' : 'Add Site'" v-model:visible="visible" @ok="onSubmit">
+    <el-form :model="form" ref="formRef">
+      <el-form-item label="Customer" prop="customerId" :rules="{ required: true, message: 'Required' }">
+        <el-select v-model="form.customerId">
+          <el-option v-for="c in customers" :key="c.id" :label="c.name" :value="c.id" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="Name" prop="name" :rules="{ required: true, message: 'Required' }">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item label="Contact" prop="contact">
+        <el-input v-model="form.contact" />
+      </el-form-item>
+      <el-form-item label="Manager" prop="manager">
+        <el-input v-model="form.manager" />
+      </el-form-item>
+      <el-form-item label="Location" prop="location">
+        <el-input v-model="form.location" />
+      </el-form-item>
+      <el-form-item label="Products" prop="deployedProducts">
+        <el-select v-model="form.deployedProducts" multiple filterable>
+          <el-option label="PACS" value="PACS" />
+          <el-option label="RIS" value="RIS" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="Description" prop="description">
+        <el-input type="textarea" v-model="form.description" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue'
+import { useCreateSite, useUpdateSite, useCustomerList } from '../api'
+import FormDialog from '@/components/FormDialog.vue'
+
+interface Props { visible: boolean; data?: any }
+const props = defineProps<Props>()
+const emit = defineEmits(['update:visible', 'saved'])
+
+const formRef = ref()
+const form = ref({
+  customerId: undefined,
+  name: '',
+  contact: '',
+  manager: '',
+  location: '',
+  deployedProducts: [] as string[],
+  description: '',
+})
+
+watch(
+  () => props.data,
+  val => {
+    if (val) Object.assign(form.value, val)
+  },
+  { immediate: true }
+)
+
+const { data: customers } = useCustomerList()
+const { mutateAsync: create } = useCreateSite()
+const { mutateAsync: update } = useUpdateSite()
+
+const onSubmit = async () => {
+  const method = props.data?.id ? update({ id: props.data.id, data: form.value }) : create(form.value)
+  await method
+  emit('update:visible', false)
+  emit('saved')
+}
+</script>

--- a/src/modules/asset/site/SiteList.vue
+++ b/src/modules/asset/site/SiteList.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <el-select v-model="customerId" placeholder="Customer" class="mb-2 mr-2">
+      <el-option label="All" value="" />
+      <el-option v-for="c in customers" :key="c.id" :label="c.name" :value="c.id" />
+    </el-select>
+    <el-input v-model="search" placeholder="Search" class="mb-2" />
+    <el-button type="primary" class="mb-2" @click="openForm">Add</el-button>
+    <TableWrapper :data="list" :pagination="{ pageSize, total, onChange }">
+      <el-table-column prop="name" label="Name" />
+      <el-table-column prop="customerName" label="Customer" />
+      <el-table-column prop="contact" label="Contact" />
+      <el-table-column prop="manager" label="Manager" />
+      <el-table-column prop="location" label="Location" />
+      <el-table-column prop="deployedProducts" label="Products" />
+      <el-table-column prop="description" label="Description" />
+      <el-table-column label="Actions">
+        <template #default="{ row }">
+          <el-button size="small" @click="edit(row)">Edit</el-button>
+          <el-button size="small" type="danger" @click="remove(row)">Delete</el-button>
+          <el-button size="small" type="primary" @click="view(row)">Detail</el-button>
+        </template>
+      </el-table-column>
+    </TableWrapper>
+    <SiteForm v-model:visible="formVisible" :data="current" @saved="refetch" />
+    <SiteDeleteDialog v-model:visible="deleteVisible" :data="current" @confirm="doDelete" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps } from 'vue'
+import { useSiteList, useDeleteSite, useCustomerList } from '../api'
+import { useRouter } from 'vue-router'
+import TableWrapper from '@/components/TableWrapper.vue'
+import SiteForm from './SiteForm.vue'
+import SiteDeleteDialog from './SiteDeleteDialog.vue'
+import { usePaginated } from '@/composables/usePaginated'
+
+const props = defineProps<{ customerId?: number }>()
+const customerId = ref(props.customerId ?? '')
+const search = ref('')
+const { data: customers } = useCustomerList()
+const { page, pageSize, total, setTotal, onChange } = usePaginated()
+const { data, refetch } = useSiteList({ search, customerId, page, pageSize })
+watch(data, () => setTotal(data.value?.length || 0))
+
+const list = data
+const formVisible = ref(false)
+const deleteVisible = ref(false)
+const current = ref()
+
+const openForm = () => {
+  current.value = undefined
+  formVisible.value = true
+}
+
+const edit = (row: any) => {
+  current.value = row
+  formVisible.value = true
+}
+
+const remove = (row: any) => {
+  current.value = row
+  deleteVisible.value = true
+}
+
+const { mutate } = useDeleteSite()
+const doDelete = () => {
+  mutate(current.value.id)
+  deleteVisible.value = false
+}
+
+const router = useRouter()
+const view = (row: any) => {
+  router.push(`/asset/site/${row.id}`)
+}
+</script>

--- a/src/modules/asset/store.ts
+++ b/src/modules/asset/store.ts
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia'
+import { Customer } from './types'
+
+export const useAssetStore = defineStore('asset', {
+  state: () => ({
+    customers: [] as Customer[],
+  }),
+  actions: {
+    setCustomers(list: Customer[]) {
+      this.customers = list
+    },
+  },
+})

--- a/src/modules/asset/types.ts
+++ b/src/modules/asset/types.ts
@@ -1,0 +1,41 @@
+export interface Customer {
+  id: number
+  name: string
+  slaLevel: string
+  level: string
+  contract: string
+  feeInfo: string
+}
+
+export interface Site {
+  id: number
+  customerId: number
+  customerName?: string
+  name: string
+  contact: string
+  manager: string
+  location: string
+  deployedProducts: string[]
+  description?: string
+}
+
+export interface RemoteAccess {
+  id: number
+  siteId: number
+  type: 'SSH' | 'RDP' | 'VNC'
+  host: string
+  port: number
+  username: string
+  passwordEncrypted: string
+}
+
+export interface HostAsset {
+  id: number
+  siteId: number
+  siteName?: string
+  hostname: string
+  ip: string
+  os: string
+  status: 'online' | 'offline'
+}
+

--- a/src/modules/auth/Login.vue
+++ b/src/modules/auth/Login.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="h-screen flex items-center justify-center">
+    <el-card class="w-96">
+      <h3 class="text-center mb-4">Login</h3>
+      <el-radio-group v-model="type" class="mb-4 flex justify-center">
+        <el-radio-button label="local">Local</el-radio-button>
+        <el-radio-button label="ldap">LDAP</el-radio-button>
+      </el-radio-group>
+      <el-form :model="form" @keyup.enter="onSubmit">
+        <el-form-item label="Username">
+          <el-input v-model="form.username" />
+        </el-form-item>
+        <el-form-item label="Password">
+          <el-input v-model="form.password" type="password" />
+        </el-form-item>
+      </el-form>
+      <div class="text-center mt-4">
+        <el-button type="primary" @click="onSubmit">Login</el-button>
+      </div>
+      <div v-if="type === 'ldap'" class="text-center text-xs mt-2">\u5185\u90e8\u5458\u5de5\u767b\u5f55</div>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useLoginLocal, useLoginLdap } from './api'
+
+const router = useRouter()
+const type = ref<'local' | 'ldap'>('local')
+const form = ref({ username: '', password: '' })
+
+const { mutateAsync: loginLocal } = useLoginLocal()
+const { mutateAsync: loginLdap } = useLoginLdap()
+
+const onSubmit = async () => {
+  if (type.value === 'ldap') {
+    await loginLdap(form.value)
+  } else {
+    await loginLocal(form.value)
+  }
+  router.push('/asset/customer')
+}
+</script>

--- a/src/modules/auth/api.ts
+++ b/src/modules/auth/api.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/vue-query'
+import { loginLocal, loginLdap, LoginPayload } from '@/api/authApi'
+import { useAuthStore } from './store'
+
+const useLogin = (fn: (data: LoginPayload) => Promise<any>) => {
+  const store = useAuthStore()
+  return useMutation(async (data: LoginPayload) => {
+    const res = await fn(data)
+    store.setToken(res.data.token)
+    return res
+  })
+}
+
+export const useLoginLocal = () => useLogin(loginLocal)
+export const useLoginLdap = () => useLogin(loginLdap)

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './api'
+export * from './router'
+export * from './store'

--- a/src/modules/auth/router.ts
+++ b/src/modules/auth/router.ts
@@ -1,0 +1,8 @@
+import { RouteRecordRaw } from 'vue-router'
+
+export const authRoutes: RouteRecordRaw[] = [
+  {
+    path: '/login',
+    component: () => import('./Login.vue'),
+  },
+]

--- a/src/modules/auth/store.ts
+++ b/src/modules/auth/store.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    token: '' as string,
+  }),
+  actions: {
+    setToken(token: string) {
+      this.token = token
+    },
+  },
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,10 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import { assetRoutes } from '../modules/asset/router'
+import { authRoutes } from '../modules/auth/router'
+
+const routes = [...authRoutes, ...assetRoutes]
+
+export const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,3 @@
+import { createPinia } from 'pinia'
+
+export const pinia = createPinia()

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,0 +1,4 @@
+export const formatDate = (d: string | number | Date) => {
+  const date = new Date(d)
+  return date.toLocaleDateString()
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{vue,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- include simple login page with switchable local or LDAP modes
- store auth token after login
- add login routes and authentication APIs
- add project configuration for Vite and Tailwind
- document how to run the project in English and Chinese

## Testing
- `git status --short`
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854000473a4832abb6fd089aa7196eb