### PR TITLE
Improve dashboard with mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# smartops-web
-smartops-web
+# SmartOps Web
+
+Vue 3 + Vite + TypeScript demo project.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+In development the KPI dashboard uses a mock service implemented with [msw](https://mswjs.io/).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SmartOps Web</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "smartops-web",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.5",
+    "pinia": "^2.1.3",
+    "axios": "^1.4.0",
+    "element-plus": "^2.3.10",
+    "@tanstack/vue-query": "^4.29.9"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.26",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="h-screen flex">
+    <SideMenu class="w-60" />
+    <router-view class="flex-1" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SideMenu from '@/components/SideMenu.vue'
+</script>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,49 @@
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: '/api',
+})
+
+export const authApi = {
+  loginLocal: (data: { username: string; password: string }) => apiClient.post('/auth/login/local', data),
+  loginLdap: (data: { username: string; password: string }) => apiClient.post('/auth/login/ldap', data),
+}
+
+export const userApi = {
+  list: (params?: Record<string, any>) => apiClient.get('/users', { params }),
+  detail: (id: string) => apiClient.get(`/users/${id}`),
+  create: (data: any) => apiClient.post('/users', data),
+  update: (id: string, data: any) => apiClient.put(`/users/${id}`, data),
+  delete: (id: string) => apiClient.delete(`/users/${id}`),
+}
+
+export const customerApi = {
+  list: (params?: Record<string, any>) => apiClient.get('/customers', { params }),
+  detail: (id: string) => apiClient.get(`/customers/${id}`),
+  create: (data: any) => apiClient.post('/customers', data),
+  update: (id: string, data: any) => apiClient.put(`/customers/${id}`, data),
+  delete: (id: string) => apiClient.delete(`/customers/${id}`),
+}
+
+export const siteApi = {
+  list: (params?: Record<string, any>) => apiClient.get('/sites', { params }),
+  detail: (id: string) => apiClient.get(`/sites/${id}`),
+  create: (data: any) => apiClient.post('/sites', data),
+  update: (id: string, data: any) => apiClient.put(`/sites/${id}`, data),
+  delete: (id: string) => apiClient.delete(`/sites/${id}`),
+}
+
+export const remoteAccessApi = {
+  list: (params?: Record<string, any>) => apiClient.get('/remote-access', { params }),
+  create: (data: any) => apiClient.post('/remote-access', data),
+  update: (id: string, data: any) => apiClient.put(`/remote-access/${id}`, data),
+  delete: (id: string) => apiClient.delete(`/remote-access/${id}`),
+}
+
+export const hostAssetApi = {
+  list: (params?: Record<string, any>) => apiClient.get('/host-assets', { params }),
+  create: (data: any) => apiClient.post('/host-assets', data),
+  update: (id: string, data: any) => apiClient.put(`/host-assets/${id}`, data),
+  delete: (id: string) => apiClient.delete(`/host-assets/${id}`),
+}
+

--- a/src/components/FormDialog.vue
+++ b/src/components/FormDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" :title="title" width="500px" @close="onClose">
+    <slot />
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="primary" @click="onSubmit">Confirm</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+
+const props = defineProps<{ modelValue: boolean; title: string }>()
+const emit = defineEmits(['update:modelValue', 'submit'])
+
+const visible = ref(props.modelValue)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+function onClose() {
+  emit('update:modelValue', false)
+}
+
+function onSubmit() {
+  emit('submit')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/SideMenu.vue
+++ b/src/components/SideMenu.vue
@@ -1,0 +1,11 @@
+<template>
+  <el-menu :router="true" class="h-full">
+    <slot />
+  </el-menu>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+</style>

--- a/src/components/TableWrapper.vue
+++ b/src/components/TableWrapper.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="p-4">
+    <el-table :data="data" border class="w-full" v-bind="$attrs">
+      <slot />
+    </el-table>
+    <div class="flex justify-end mt-2">
+      <el-pagination
+        v-if="pagination"
+        background
+        layout="prev, pager, next"
+        :total="pagination.total"
+        :current-page="pagination.page"
+        :page-size="pagination.pageSize"
+        @current-change="onPageChange"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue'
+
+interface Pagination {
+  page: number
+  pageSize: number
+  total: number
+}
+
+const props = defineProps<{ data: any[]; pagination?: Pagination }>()
+const emit = defineEmits(['update:page'])
+
+function onPageChange(page: number) {
+  emit('update:page', page)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import { authApi } from '@/api'
+
+export function useAuth() {
+  const loading = ref(false)
+
+  async function loginLocal(username: string, password: string) {
+    loading.value = true
+    try {
+      const res = await authApi.loginLocal({ username, password })
+      return res.data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function loginLdap(username: string, password: string) {
+    loading.value = true
+    try {
+      const res = await authApi.loginLdap({ username, password })
+      return res.data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { loading, loginLocal, loginLdap }
+}

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,0 +1,15 @@
+import { ref } from 'vue'
+
+export function useModal() {
+  const visible = ref(false)
+
+  function open() {
+    visible.value = true
+  }
+
+  function close() {
+    visible.value = false
+  }
+
+  return { visible, open, close }
+}

--- a/src/composables/usePaginated.ts
+++ b/src/composables/usePaginated.ts
@@ -1,0 +1,16 @@
+import { ref } from 'vue'
+
+export function usePaginated<T>() {
+  const data = ref<T[]>([])
+  const page = ref(1)
+  const pageSize = ref(10)
+  const total = ref(0)
+  const loading = ref(false)
+
+  function setResult(result: { items: T[]; total: number }) {
+    data.value = result.items
+    total.value = result.total
+  }
+
+  return { data, page, pageSize, total, loading, setResult }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,20 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+import store from './store'
+import { VueQueryPlugin } from '@tanstack/vue-query'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import './styles/tailwind.css'
+import { initMocks } from './mocks/kpis'
+
+if (import.meta.env.DEV) {
+  initMocks()
+}
+
+createApp(App)
+  .use(store)
+  .use(router)
+  .use(VueQueryPlugin)
+  .use(ElementPlus)
+  .mount('#app')

--- a/src/mocks/kpis.ts
+++ b/src/mocks/kpis.ts
@@ -1,0 +1,14 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/api/kpis', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({ totalOrders: 120, activeUsers: 50, errorRate: 0.02 })
+    )
+  })
+)
+
+export function initMocks() {
+  worker.start()
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,18 @@
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
+
+const routes: RouteRecordRaw[] = [
+  { path: '/login', component: () => import('@/views/auth/Login.vue') },
+  { path: '/', component: () => import('@/views/dashboard/Dashboard.vue') },
+  { path: '/users', component: () => import('@/views/user/UserList.vue') },
+  { path: '/customers', component: () => import('@/views/asset/customer/CustomerList.vue') },
+  { path: '/sites', component: () => import('@/views/asset/site/SiteList.vue') },
+  { path: '/remote-access', component: () => import('@/views/asset/remote-access/RemoteAccessList.vue') },
+  { path: '/host-assets', component: () => import('@/views/asset/host-asset/HostAssetList.vue') },
+]
+
+export const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,5 @@
+import { createPinia } from 'pinia'
+
+export const store = createPinia()
+
+export default store

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/views/asset/customer/CustomerDeleteDialog.vue
+++ b/src/views/asset/customer/CustomerDeleteDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" title="Confirm" width="300px">
+    <span>Are you sure to delete this customer?</span>
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="danger" @click="onDelete">Delete</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { customerApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+async function onDelete() {
+  if (props.id) {
+    await customerApi.delete(props.id)
+    emit('refresh')
+  }
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/customer/CustomerForm.vue
+++ b/src/views/asset/customer/CustomerForm.vue
@@ -1,0 +1,44 @@
+<template>
+  <FormDialog v-model="visible" :title="id ? 'Edit Customer' : 'New Customer'" @submit="onSubmit">
+    <el-form :model="form" label-position="top">
+      <el-form-item label="Name">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item label="Contact">
+        <el-input v-model="form.contact" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect, reactive } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+import { customerApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+const form = reactive({ name: '', contact: '' })
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await customerApi.detail(props.id)
+    Object.assign(form, res.data)
+  }
+})
+
+async function onSubmit() {
+  if (props.id) {
+    await customerApi.update(props.id, form)
+  } else {
+    await customerApi.create(form)
+  }
+  emit('update:modelValue', false)
+  emit('refresh')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/customer/CustomerList.vue
+++ b/src/views/asset/customer/CustomerList.vue
@@ -1,0 +1,54 @@
+<template>
+  <TableWrapper :data="customers" :pagination="pagination" @update:page="onPageChange">
+    <el-table-column prop="name" label="Name" />
+    <el-table-column prop="contact" label="Contact" />
+    <el-table-column label="Actions">
+      <template #default="{ row }">
+        <el-button size="small" @click="openEdit(row.id)">Edit</el-button>
+        <el-button size="small" type="danger" @click="openDelete(row.id)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </TableWrapper>
+  <CustomerForm v-model="showForm" :id="currentId" @refresh="fetchData" />
+  <CustomerDeleteDialog v-model="showDelete" :id="currentId" @refresh="fetchData" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import TableWrapper from '@/components/TableWrapper.vue'
+import CustomerForm from './CustomerForm.vue'
+import CustomerDeleteDialog from './CustomerDeleteDialog.vue'
+import { customerApi } from '@/api'
+import { usePaginated } from '@/composables/usePaginated'
+
+const { data: customers, page, pageSize, total, setResult } = usePaginated<any>()
+const pagination = { page, pageSize, total }
+const showForm = ref(false)
+const showDelete = ref(false)
+const currentId = ref<string | null>(null)
+
+async function fetchData() {
+  const res = await customerApi.list({ page: page.value, pageSize: pageSize.value })
+  setResult({ items: res.data.items, total: res.data.total })
+}
+
+function onPageChange(p: number) {
+  page.value = p
+  fetchData()
+}
+
+function openEdit(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openDelete(id: string) {
+  currentId.value = id
+  showDelete.value = true
+}
+
+onMounted(fetchData)
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/host-asset/HostAssetDeleteDialog.vue
+++ b/src/views/asset/host-asset/HostAssetDeleteDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" title="Confirm" width="300px">
+    <span>Are you sure to delete this asset?</span>
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="danger" @click="onDelete">Delete</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { hostAssetApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+async function onDelete() {
+  if (props.id) {
+    await hostAssetApi.delete(props.id)
+    emit('refresh')
+  }
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/host-asset/HostAssetForm.vue
+++ b/src/views/asset/host-asset/HostAssetForm.vue
@@ -1,0 +1,53 @@
+<template>
+  <FormDialog v-model="visible" :title="id ? 'Edit Host Asset' : 'New Host Asset'" @submit="onSubmit">
+    <el-form :model="form" label-position="top">
+      <el-form-item label="Hostname">
+        <el-input v-model="form.hostname" />
+      </el-form-item>
+      <el-form-item label="IP">
+        <el-input v-model="form.ip" />
+      </el-form-item>
+      <el-form-item label="OS">
+        <el-input v-model="form.os" />
+      </el-form-item>
+      <el-form-item label="Status">
+        <el-input v-model="form.status" />
+      </el-form-item>
+      <el-form-item label="Site">
+        <el-input v-model="form.siteName" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect, reactive } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+import { hostAssetApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+const form = reactive({ hostname: '', ip: '', os: '', status: '', siteName: '' })
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await hostAssetApi.list({ id: props.id })
+    Object.assign(form, res.data)
+  }
+})
+
+async function onSubmit() {
+  if (props.id) {
+    await hostAssetApi.update(props.id, form)
+  } else {
+    await hostAssetApi.create(form)
+  }
+  emit('update:modelValue', false)
+  emit('refresh')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/host-asset/HostAssetList.vue
+++ b/src/views/asset/host-asset/HostAssetList.vue
@@ -1,0 +1,57 @@
+<template>
+  <TableWrapper :data="items" :pagination="pagination" @update:page="onPageChange">
+    <el-table-column prop="hostname" label="Hostname" />
+    <el-table-column prop="ip" label="IP" />
+    <el-table-column prop="os" label="OS" />
+    <el-table-column prop="status" label="Status" />
+    <el-table-column prop="siteName" label="Site" />
+    <el-table-column label="Actions">
+      <template #default="{ row }">
+        <el-button size="small" @click="openEdit(row.id)">Edit</el-button>
+        <el-button size="small" type="danger" @click="openDelete(row.id)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </TableWrapper>
+  <HostAssetForm v-model="showForm" :id="currentId" @refresh="fetchData" />
+  <HostAssetDeleteDialog v-model="showDelete" :id="currentId" @refresh="fetchData" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import TableWrapper from '@/components/TableWrapper.vue'
+import HostAssetForm from './HostAssetForm.vue'
+import HostAssetDeleteDialog from './HostAssetDeleteDialog.vue'
+import { hostAssetApi } from '@/api'
+import { usePaginated } from '@/composables/usePaginated'
+
+const { data: items, page, pageSize, total, setResult } = usePaginated<any>()
+const pagination = { page, pageSize, total }
+const showForm = ref(false)
+const showDelete = ref(false)
+const currentId = ref<string | null>(null)
+
+async function fetchData() {
+  const res = await hostAssetApi.list({ page: page.value, pageSize: pageSize.value })
+  setResult({ items: res.data.items, total: res.data.total })
+}
+
+function onPageChange(p: number) {
+  page.value = p
+  fetchData()
+}
+
+function openEdit(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openDelete(id: string) {
+  currentId.value = id
+  showDelete.value = true
+}
+
+onMounted(fetchData)
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/remote-access/RemoteAccessDeleteDialog.vue
+++ b/src/views/asset/remote-access/RemoteAccessDeleteDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" title="Confirm" width="300px">
+    <span>Are you sure to delete this item?</span>
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="danger" @click="onDelete">Delete</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { remoteAccessApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+async function onDelete() {
+  if (props.id) {
+    await remoteAccessApi.delete(props.id)
+    emit('refresh')
+  }
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/remote-access/RemoteAccessForm.vue
+++ b/src/views/asset/remote-access/RemoteAccessForm.vue
@@ -1,0 +1,49 @@
+<template>
+  <FormDialog v-model="visible" :title="id ? 'Edit Access' : 'New Access'" @submit="onSubmit">
+    <el-form :model="form" label-position="top">
+      <el-form-item label="Host">
+        <el-input v-model="form.host" />
+      </el-form-item>
+      <el-form-item label="Username">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="Password">
+        <el-input :type="showPassword ? 'text' : 'password'" v-model="form.password" />
+        <el-button @click="showPassword = !showPassword" size="small" class="ml-2">{{ showPassword ? 'Hide' : 'Show' }}</el-button>
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect, reactive } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+import { remoteAccessApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+const showPassword = ref(false)
+const form = reactive({ host: '', username: '', password: '' })
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await remoteAccessApi.list({ id: props.id })
+    Object.assign(form, res.data)
+  }
+})
+
+async function onSubmit() {
+  if (props.id) {
+    await remoteAccessApi.update(props.id, form)
+  } else {
+    await remoteAccessApi.create(form)
+  }
+  emit('update:modelValue', false)
+  emit('refresh')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/remote-access/RemoteAccessList.vue
+++ b/src/views/asset/remote-access/RemoteAccessList.vue
@@ -1,0 +1,54 @@
+<template>
+  <TableWrapper :data="items" :pagination="pagination" @update:page="onPageChange">
+    <el-table-column prop="host" label="Host" />
+    <el-table-column prop="username" label="Username" />
+    <el-table-column label="Actions">
+      <template #default="{ row }">
+        <el-button size="small" @click="openEdit(row.id)">Edit</el-button>
+        <el-button size="small" type="danger" @click="openDelete(row.id)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </TableWrapper>
+  <RemoteAccessForm v-model="showForm" :id="currentId" @refresh="fetchData" />
+  <RemoteAccessDeleteDialog v-model="showDelete" :id="currentId" @refresh="fetchData" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import TableWrapper from '@/components/TableWrapper.vue'
+import RemoteAccessForm from './RemoteAccessForm.vue'
+import RemoteAccessDeleteDialog from './RemoteAccessDeleteDialog.vue'
+import { remoteAccessApi } from '@/api'
+import { usePaginated } from '@/composables/usePaginated'
+
+const { data: items, page, pageSize, total, setResult } = usePaginated<any>()
+const pagination = { page, pageSize, total }
+const showForm = ref(false)
+const showDelete = ref(false)
+const currentId = ref<string | null>(null)
+
+async function fetchData() {
+  const res = await remoteAccessApi.list({ page: page.value, pageSize: pageSize.value })
+  setResult({ items: res.data.items, total: res.data.total })
+}
+
+function onPageChange(p: number) {
+  page.value = p
+  fetchData()
+}
+
+function openEdit(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openDelete(id: string) {
+  currentId.value = id
+  showDelete.value = true
+}
+
+onMounted(fetchData)
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/site/SiteDeleteDialog.vue
+++ b/src/views/asset/site/SiteDeleteDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" title="Confirm" width="300px">
+    <span>Are you sure to delete this site?</span>
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="danger" @click="onDelete">Delete</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { siteApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+async function onDelete() {
+  if (props.id) {
+    await siteApi.delete(props.id)
+    emit('refresh')
+  }
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/site/SiteDetail.vue
+++ b/src/views/asset/site/SiteDetail.vue
@@ -1,0 +1,31 @@
+<template>
+  <el-drawer v-model="visible" :with-header="false" size="400px">
+    <el-descriptions :title="site?.name" column="1">
+      <el-descriptions-item label="Contact">{{ site?.contact }}</el-descriptions-item>
+      <el-descriptions-item label="Manager">{{ site?.manager }}</el-descriptions-item>
+      <el-descriptions-item label="Location">{{ site?.location }}</el-descriptions-item>
+      <el-descriptions-item label="Description">{{ site?.description }}</el-descriptions-item>
+    </el-descriptions>
+  </el-drawer>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { siteApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue'])
+const visible = ref(false)
+const site = ref<any>()
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await siteApi.detail(props.id)
+    site.value = res.data
+  }
+})
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/site/SiteForm.vue
+++ b/src/views/asset/site/SiteForm.vue
@@ -1,0 +1,66 @@
+<template>
+  <FormDialog v-model="visible" :title="id ? 'Edit Site' : 'New Site'" @submit="onSubmit">
+    <el-form :model="form" label-position="top">
+      <el-form-item label="Name">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item label="Contact">
+        <el-input v-model="form.contact" />
+      </el-form-item>
+      <el-form-item label="Manager">
+        <el-input v-model="form.manager" />
+      </el-form-item>
+      <el-form-item label="Deployed Products">
+        <el-select v-model="form.deployedProducts" multiple>
+          <el-option label="Product A" value="A" />
+          <el-option label="Product B" value="B" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="Location">
+        <el-input v-model="form.location" />
+      </el-form-item>
+      <el-form-item label="Description">
+        <el-input type="textarea" v-model="form.description" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect, reactive } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+import { siteApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+const form = reactive({
+  name: '',
+  contact: '',
+  manager: '',
+  deployedProducts: [] as string[],
+  location: '',
+  description: '',
+})
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await siteApi.detail(props.id)
+    Object.assign(form, res.data)
+  }
+})
+
+async function onSubmit() {
+  if (props.id) {
+    await siteApi.update(props.id, form)
+  } else {
+    await siteApi.create(form)
+  }
+  emit('update:modelValue', false)
+  emit('refresh')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/asset/site/SiteList.vue
+++ b/src/views/asset/site/SiteList.vue
@@ -1,0 +1,54 @@
+<template>
+  <TableWrapper :data="sites" :pagination="pagination" @update:page="onPageChange">
+    <el-table-column prop="name" label="Name" />
+    <el-table-column prop="location" label="Location" />
+    <el-table-column label="Actions">
+      <template #default="{ row }">
+        <el-button size="small" @click="openEdit(row.id)">Edit</el-button>
+        <el-button size="small" type="danger" @click="openDelete(row.id)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </TableWrapper>
+  <SiteForm v-model="showForm" :id="currentId" @refresh="fetchData" />
+  <SiteDeleteDialog v-model="showDelete" :id="currentId" @refresh="fetchData" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import TableWrapper from '@/components/TableWrapper.vue'
+import SiteForm from './SiteForm.vue'
+import SiteDeleteDialog from './SiteDeleteDialog.vue'
+import { siteApi } from '@/api'
+import { usePaginated } from '@/composables/usePaginated'
+
+const { data: sites, page, pageSize, total, setResult } = usePaginated<any>()
+const pagination = { page, pageSize, total }
+const showForm = ref(false)
+const showDelete = ref(false)
+const currentId = ref<string | null>(null)
+
+async function fetchData() {
+  const res = await siteApi.list({ page: page.value, pageSize: pageSize.value })
+  setResult({ items: res.data.items, total: res.data.total })
+}
+
+function onPageChange(p: number) {
+  page.value = p
+  fetchData()
+}
+
+function openEdit(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openDelete(id: string) {
+  currentId.value = id
+  showDelete.value = true
+}
+
+onMounted(fetchData)
+</script>
+
+<style scoped>
+</style>

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="flex justify-center items-center h-screen">
+    <el-card class="w-96">
+      <div class="flex justify-between mb-4">
+        <el-radio-group v-model="mode">
+          <el-radio-button label="local">Local</el-radio-button>
+          <el-radio-button label="ldap">LDAP</el-radio-button>
+        </el-radio-group>
+      </div>
+      <el-form :model="form" label-position="top">
+        <el-form-item label="Username">
+          <el-input v-model="form.username" />
+        </el-form-item>
+        <el-form-item label="Password">
+          <el-input v-model="form.password" type="password" />
+        </el-form-item>
+      </el-form>
+      <div class="text-right">
+        <el-button type="primary" :loading="loading" @click="onSubmit">Login</el-button>
+      </div>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import { useAuth } from '@/composables/useAuth'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const { loginLocal, loginLdap, loading } = useAuth()
+const mode = ref<'local' | 'ldap'>('local')
+const form = reactive({ username: '', password: '' })
+
+async function onSubmit() {
+  const { username, password } = form
+  if (mode.value === 'local') {
+    await loginLocal(username, password)
+  } else {
+    await loginLdap(username, password)
+  }
+  router.push('/')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/dashboard/Dashboard.vue
+++ b/src/views/dashboard/Dashboard.vue
@@ -1,0 +1,34 @@
+<template>
+  <div v-if="loading">加载中…</div>
+  <div v-else-if="data" class="p-4 grid grid-cols-1 md:grid-cols-4 gap-4">
+    <el-card v-for="(value, key) in data" :key="key" class="text-center">
+      <div class="text-xl">{{ value }}</div>
+      <div class="text-gray-500">{{ key }}</div>
+    </el-card>
+  </div>
+  <div v-else>暂无数据</div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+import { ElMessage } from 'element-plus'
+
+const data = ref<Record<string, number> | null>(null)
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    const res = await axios.get('/api/kpis')
+    data.value = res.data
+  } catch (err) {
+    ElMessage.error('获取 KPI 数据失败，请稍后重试')
+    console.error(err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+</style>

--- a/src/views/user/UserDeleteDialog.vue
+++ b/src/views/user/UserDeleteDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-dialog v-model="visible" title="Confirm" width="300px">
+    <span>Are you sure to delete this user?</span>
+    <template #footer>
+      <el-button @click="visible = false">Cancel</el-button>
+      <el-button type="danger" @click="onDelete">Delete</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { userApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+
+watchEffect(() => {
+  visible.value = props.modelValue
+})
+
+async function onDelete() {
+  if (props.id) {
+    await userApi.delete(props.id)
+    emit('refresh')
+  }
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/user/UserDetail.vue
+++ b/src/views/user/UserDetail.vue
@@ -1,0 +1,29 @@
+<template>
+  <el-drawer v-model="visible" :with-header="false" size="400px">
+    <el-descriptions :title="user?.username" column="1">
+      <el-descriptions-item label="Email">{{ user?.email }}</el-descriptions-item>
+      <el-descriptions-item label="Role">{{ user?.role }}</el-descriptions-item>
+    </el-descriptions>
+  </el-drawer>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+import { userApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue'])
+const visible = ref(false)
+const user = ref<any>()
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await userApi.detail(props.id)
+    user.value = res.data
+  }
+})
+</script>
+
+<style scoped>
+</style>

--- a/src/views/user/UserForm.vue
+++ b/src/views/user/UserForm.vue
@@ -1,0 +1,47 @@
+<template>
+  <FormDialog v-model="visible" :title="id ? 'Edit User' : 'New User'" @submit="onSubmit">
+    <el-form :model="form" label-position="top">
+      <el-form-item label="Username">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="Email">
+        <el-input v-model="form.email" />
+      </el-form-item>
+      <el-form-item label="Role">
+        <el-input v-model="form.role" />
+      </el-form-item>
+    </el-form>
+  </FormDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watchEffect, reactive } from 'vue'
+import FormDialog from '@/components/FormDialog.vue'
+import { userApi } from '@/api'
+
+const props = defineProps<{ modelValue: boolean; id: string | null }>()
+const emit = defineEmits(['update:modelValue', 'refresh'])
+const visible = ref(false)
+const form = reactive({ username: '', email: '', role: '' })
+
+watchEffect(async () => {
+  visible.value = props.modelValue
+  if (props.id) {
+    const res = await userApi.detail(props.id)
+    Object.assign(form, res.data)
+  }
+})
+
+async function onSubmit() {
+  if (props.id) {
+    await userApi.update(props.id, form)
+  } else {
+    await userApi.create(form)
+  }
+  emit('update:modelValue', false)
+  emit('refresh')
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/views/user/UserList.vue
+++ b/src/views/user/UserList.vue
@@ -1,0 +1,60 @@
+<template>
+  <TableWrapper :data="users" :pagination="pagination" @update:page="onPageChange">
+    <el-table-column prop="username" label="Username" />
+    <el-table-column prop="email" label="Email" />
+    <el-table-column label="Actions">
+      <template #default="{ row }">
+        <el-button size="small" @click="openDetail(row.id)">Detail</el-button>
+        <el-button size="small" @click="openEdit(row.id)">Edit</el-button>
+        <el-button size="small" type="danger" @click="openDelete(row.id)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </TableWrapper>
+  <UserForm v-model="showForm" :id="currentId" @refresh="fetchUsers" />
+  <UserDeleteDialog v-model="showDelete" :id="currentId" @refresh="fetchUsers" />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import TableWrapper from '@/components/TableWrapper.vue'
+import UserForm from './UserForm.vue'
+import UserDeleteDialog from './UserDeleteDialog.vue'
+import { userApi } from '@/api'
+import { usePaginated } from '@/composables/usePaginated'
+
+const { data: users, page, pageSize, total, setResult } = usePaginated<any>()
+const pagination = { page, pageSize, total }
+const showForm = ref(false)
+const showDelete = ref(false)
+const currentId = ref<string | null>(null)
+
+async function fetchUsers() {
+  const res = await userApi.list({ page: page.value, pageSize: pageSize.value })
+  setResult({ items: res.data.items, total: res.data.total })
+}
+
+function onPageChange(p: number) {
+  page.value = p
+  fetchUsers()
+}
+
+function openDetail(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openEdit(id: string) {
+  currentId.value = id
+  showForm.value = true
+}
+
+function openDelete(id: string) {
+  currentId.value = id
+  showDelete.value = true
+}
+
+onMounted(fetchUsers)
+</script>
+
+<style scoped>
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "useDefineForClassFields": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "lib": ["ESNext", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    hmr: {
+      overlay: false,
+    },
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api/, '/api'),
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add msw mock setup and proxy in vite
- handle KPI fetch errors in Dashboard
- disable Vite overlay during HMR
- document usage steps in README

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cafbc05cc832a8ad20ef9709d9109